### PR TITLE
Re-enable support for Pelican 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,21 @@ will also install the required dependencies (currently ``pelican`` and
 
   pip install pelican-jinja-filters
 
-As ``Jinja Filters`` is a namespace plugin, it should automatically be loaded
-by Pelican. And that's it! The filters are now available for use in your
-templates.
+As ``Jinja Filters`` is a namespace plugin, assuming you are using Pelican 4.5
+(or newer) **and** *only* other namespace plugins, ``Jinja Filters`` will be
+automatically be loaded by Pelican. And that's it!
+
+If you are using an older version of Pelican, or non-namespace plugins, you may
+need to add ``Jinja Filters`` to your ``pelicanconf.py``:
+
+.. code-block:: python
+
+  PLUGINS = [
+      # others...
+      "pelican.plugins.jinja_filters",
+  ]
+
+The filters are now available for use in your templates.
 
 
 Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ packages = [
     { include = "pelican" },
 ]
 include = [
+    "README.rst",
     "LICENSE.txt",
     "CHANGELOG.rst",
     "CONTRIBUTING.md",
@@ -41,18 +42,18 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-pelican = "^4.5"
-markdown = {version = "^3.2.2", optional = true}
-titlecase = "^1.1.1"
+pelican = "^3 || ^4"
+markdown = {version = "^3.2", optional = true}
+titlecase = "^1.1.1 || ^2"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^19.10b0", allow-prereleases = true}
 flake8 = "^3.8"
 flake8-black = "^0.1.0"
 invoke = "^1.3"
-isort = "^5.4.2"
+isort = "^5.4"
 livereload = "^2.6"
-markdown = "^3.2.2"
+markdown = "^3.2"
 Werkzeug = "^1.0"
 
 [tool.poetry.extras]


### PR DESCRIPTION
There is nothing in the nature of the project that precludes it working pre-Pelican 4.5 and so this loosens the project requirements to support both Pelican 3 and 4.

(I'm not as familiar with Pelican 3's history, so many the minimum version should be something more recent than version 3.0).

In any case, I need this on my side as I'm currently at Pelican 3.7.1 (that last 3.x release) while working to upgrade all my plugins to support Pelican 4.x.

Also, `titlecase` version 1.1.1 or 2.0.0 works fine.

This also expands the Readme to explain how to use this as "traditionally" (i.e. not relying on it being a namespace plugin for loading).