### PR TITLE
Use `poetry-core` over `poetry` as a build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,5 @@ multi_line_output = 3
 force_sort_within_sections = true
 
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
From the (current) [poetry docs](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517)

> If your pyproject.toml file still references poetry directly as a build backend, you should update it to reference poetry_core instead.

From the [poetry-core readme](https://github.com/python-poetry/poetry-core#why-is-this-required):

> ### Why is this required?
> 
> Prior to the release of version 1.1.0, Poetry was a build as a project management tool that included a PEP 517 build backend. This was inefficient and time consuming in majority cases a PEP 517 build was required. For example, both pip and tox (with isolated builds) would install Poetry and all dependencies it required. Most of these dependencies are not required when the objective is to simply build either a source or binary distribution of your project.
> 
> In order to improve the above situation, poetry-core was created. Shared functionality pertaining to PEP 517 build backends, including reading lock file, pyproject.toml and building wheel/sdist, were implemented in this package. This makes PEP 517 builds extremely fast for Poetry managed packages.

So this seems to be current best practice, and may help streamline the project.