### PR TITLE
[Changelog] Add v1.1.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,14 @@ Jinja Filters Changelog
 - **support** first release to PyPI under `pelican-jinja-filters`_
 - see `Pull Request #4`_.
 
+1.1.0 - 2021-04-29
+------------------
+
+- **support** add warning message to point users to new plugin location at
+  ``pelican-jinja-filters`` on PyPI. See `Issue #7`_.
+
+.. _Issue #7: https://github.com/pelican-plugins/jinja-filters/issues/7
+
 1.0.4 - 2017-04-17
 ------------------
 


### PR DESCRIPTION
c.f. #7;
c.f. https://github.com/pelican-plugins/jinja-filters/commit/7ff7baf6a5bf1f1f4cf319264276b424cb6cb89a

This add reference to the v1.1.0 release that I just put out on the old namespace. The idea is that if users upgrade, they'll continue to have a working setup, but now every time they generate their site, they'll be a warning to upgrade:

![image](https://user-images.githubusercontent.com/1548809/116646956-a797be80-a936-11eb-848b-748cbea00e5b.png)

All this Pull Request does is add the v1.1.0 release to the changelog.

I've also pushed the code here on the `1.x` branch. I think there is an option to make certain branches "protected branches", so maybe we should do that for the `1.x` branch. I don't anticipate pushing any more code to it.