### PR TITLE
[isort] Add Pelican as separate import section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,14 +72,14 @@ version-header = "-"
 
 [tool.isort]
 # Maintain compatibility with Black
-combine_as_imports = true
-force_grid_wrap = 0
-include_trailing_comma = true
-line_length = 88
-multi_line_output = 3
+profile = "black"
 
 # Sort imports within their section independent of the import type
 force_sort_within_sections = true
+
+# Designate "pelican" as separate import section
+known_pelican = "pelican"
+sections = "FUTURE,STDLIB,THIRDPARTY,PELICAN,FIRSTPARTY,LOCALFOLDER"
 
 [tool.black]
 line-length = 88

--- a/tasks.py
+++ b/tasks.py
@@ -49,7 +49,7 @@ def isort(c, check=False, diff=False):
         check_flag = "-c"
     if diff:
         diff_flag = "--diff"
-    c.run(f"{CMD_PREFIX}isort {check_flag} {diff_flag} .")
+    c.run(f"{CMD_PREFIX}isort {check_flag} {diff_flag} {PKG_PATH} tasks.py test")
 
 
 @task


### PR DESCRIPTION
Pulled from another plugin, or perhaps from *pelican* proper.

Doesn't actually seem to change how the imports are sorted though....