### PR TITLE
Support datetime + URL settings that strip the leading zero

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,12 +4,12 @@ Jinja Filters Changelog
 2.1.0 - 2021-04-28
 ------------------
 
-- **feature** add ``merge_date_url`` filter. See `Pull Request #12`_.
-- **feature** add ``datetime_from_period`` filter. `Pull Request #12`_.
-- **support** rework supporting ``tasks.py`` (for use with ``invoke``). See
+- **feature**: Add ``merge_date_url`` filter. See `Pull Request #12`_.
+- **feature**: Add ``datetime_from_period`` filter. `Pull Request #12`_.
+- **support**: Rework supporting ``tasks.py`` (for use with ``invoke``). See
   `Pull Request #8`_.
-- **support** add test suite
-- **support** support Pelican from version 3.0 on. See `Pull Request #10`_.
+- **support**: Add test suite
+- **support**: Support Pelican from version 3.0 on. See `Pull Request #10`_.
 
 .. _Pull Request #8: https://github.com/pelican-plugins/jinja-filters/pull/8
 .. _Pull Request #10: https://github.com/pelican-plugins/jinja-filters/pull/10
@@ -18,19 +18,19 @@ Jinja Filters Changelog
 2.0.0 - 2020-08-21
 ------------------
 
-- **feature** Initial release as namespace plugin. With Pelican 4.5,
+- **feature**: Initial release as namespace plugin. With Pelican 4.5,
   namespace plugins no longer need to be explicitly declared to be available to
   Pelican.
-- **support** minimum version of Pelican is now 4.5
-- **support** Move plugin to the `Pelican Plugins`_ organization on GitHub. The
+- **support**: Minimum version of Pelican is now 4.5
+- **support**: Move plugin to the `Pelican Plugins`_ organization on GitHub. The
   code for the project is now at `pelican-plugins/jinja-filters`_
-- **support** first release to PyPI under `pelican-jinja-filters`_
+- **support**: First release to PyPI under `pelican-jinja-filters`_
 - see `Pull Request #4`_.
 
 1.1.0 - 2021-04-29
 ------------------
 
-- **support** add warning message to point users to new plugin location at
+- **support**: Add warning message to point users to new plugin location at
   ``pelican-jinja-filters`` on PyPI. See `Issue #7`_.
 
 .. _Issue #7: https://github.com/pelican-plugins/jinja-filters/issues/7
@@ -38,21 +38,21 @@ Jinja Filters Changelog
 1.0.4 - 2017-04-17
 ------------------
 
-- **bug** upgrade release machinery
-- **bug** add Pelican trove classifier
+- **bug**: Upgrade release machinery
+- **bug**: Add Pelican trove classifier
 
 1.0.1 - 2017-03-08
 ------------------
 
-- **bug** provide universal wheels
+- **bug**: Provide universal wheels
 
 1.0.0 - 2016-11-06
 ------------------
 
-- **feature** copy existing code from personal website
-- **support** add release machinery
-- **support** first release to PyPI under `minchin.pelican.jinja_filters`_
-- **support** add 'setup.py', 'CHANGELOG.rst', 'README.rst'
+- **feature**: Copy existing code from personal website
+- **support**: Add release machinery
+- **support**: First release to PyPI under `minchin.pelican.jinja_filters`_
+- **support**: Add 'setup.py', 'CHANGELOG.rst', 'README.rst'
 
 
 .. _minchin.pelican.jinja_filters: https://pypi.org/project/minchin.pelican.jinja_filters/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+Release type: patch
+
+- **bug**: [merge_date_url] Don't blow up when passed a URL setting that contains "-" (eg. "{date:%-d}").
+- **support**: Better error logging for when one of the filters fail.
+- **support**: (Manually) add v1.1.0 release to Changelog.

--- a/pelican/plugins/jinja_filters/jinja_filters.py
+++ b/pelican/plugins/jinja_filters/jinja_filters.py
@@ -1,5 +1,6 @@
 """Various filters for Jinja."""
 
+import logging
 
 from titlecase import titlecase as _titlecase
 
@@ -11,6 +12,10 @@ __all__ = [
     "datetime",
     "titlecase",
 ]
+
+
+LOG_PREFIX = "[Jinja Filters]"
+logger = logging.getLogger(__name__)
 
 
 def datetime(value, format_str="%Y/%m/%d %H:%M"):
@@ -29,7 +34,17 @@ def datetime(value, format_str="%Y/%m/%d %H:%M"):
         str: value, after the format_str has been applied
 
     """
-    return value.strftime(format_str)
+    try:
+        return value.strftime(format_str)
+    except ValueError as e:
+        logger.error(
+            "%s ValueError. value: %s, type(value): %s, format_str: %s",
+            LOG_PREFIX,
+            value,
+            type(value),
+            format_str,
+        )
+        raise e
 
 
 def article_date(value):
@@ -47,7 +62,13 @@ def article_date(value):
         str: value, formatted nicely for displaying the date.
 
     """
-    return "{dt:%A}, {dt:%B} {dt.day}, {dt.year}".format(dt=value)
+    try:
+        return "{dt:%A}, {dt:%B} {dt.day}, {dt.year}".format(dt=value)
+    except ValueError as e:
+        logger.error(
+            "%s ValueError. value: %s, type(value): %s", LOG_PREFIX, value, type(value)
+        )
+        raise e
 
 
 def datetime_from_period(value):

--- a/pelican/plugins/jinja_filters/jinja_filters.py
+++ b/pelican/plugins/jinja_filters/jinja_filters.py
@@ -133,7 +133,23 @@ def merge_date_url(value, url):
         string: combined URL
 
     """
-    return url.format(date=value)
+    try:
+        return url.format(date=value)
+    except ValueError:
+        # will throw a "ValueError" if the value is a datetime.datetime and the url
+        # contains a "-" (e.g. "{date:%-d}") (used in Pelican to strip the leading
+        # zero)
+        try:
+            return url.format(date=SafeDatetime(value.year, value.month, value.day))
+        except ValueError as e:
+            logger.error(
+                "%s ValueError. value: %s, type(value): %s, url: %s",
+                LOG_PREFIX,
+                value,
+                type(value),
+                url,
+            )
+            raise e
 
 
 def breaking_spaces(value):

--- a/pelican/plugins/jinja_filters/jinja_filters.py
+++ b/pelican/plugins/jinja_filters/jinja_filters.py
@@ -1,8 +1,9 @@
 """Various filters for Jinja."""
 
-from datetime import datetime as _datetime
 
 from titlecase import titlecase as _titlecase
+
+from pelican.utils import SafeDatetime
 
 __all__ = [
     "article_date",
@@ -79,9 +80,9 @@ def datetime_from_period(value):
         value = (value,)
 
     if len(value) >= 2 and isinstance(value[1], int):
-        placeholder_month = _datetime(2021, value[1], 1).strftime("%B")
+        placeholder_month = SafeDatetime(2021, value[1], 1).strftime("%B")
     elif len(value) == 1:
-        placeholder_month = _datetime(2021, 1, 1).strftime("%B")
+        placeholder_month = SafeDatetime(2021, 1, 1).strftime("%B")
     else:
         placeholder_month = value[1]
 
@@ -92,7 +93,7 @@ def datetime_from_period(value):
             str(value[2]) if len(value) >= 3 else "1",
         )
     )
-    new_datetime = _datetime.strptime(new_value, "%Y %B %d")
+    new_datetime = SafeDatetime.strptime(new_value, "%Y %B %d")
     return new_datetime
 
 

--- a/test/test_merge_date_url.py
+++ b/test/test_merge_date_url.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import unittest
 
 from pelican.plugins.jinja_filters import jinja_filters
+from pelican.utils import SafeDatetime
 
 
 class Test_Merge_Date_URL(unittest.TestCase):
@@ -28,6 +29,36 @@ class Test_Merge_Date_URL(unittest.TestCase):
         assert (
             jinja_filters.merge_date_url(my_date, self.DAY_ARCHIVE_URL)
             == "posts/2016/11/04/"
+        )
+
+    def test_pelican_year(self):
+        my_date = SafeDatetime(2016, 11, 4, 12, 34)
+        assert (
+            jinja_filters.merge_date_url(my_date, self.YEAR_ARCHIVE_URL)
+            == "posts/2016/"
+        )
+
+    def test_pelican_month(self):
+        my_date = SafeDatetime(2016, 11, 4, 12, 34)
+        assert (
+            jinja_filters.merge_date_url(my_date, self.MONTH_ARCHIVE_URL)
+            == "posts/2016/11/"
+        )
+
+    def test_pelican_day(self):
+        my_date = SafeDatetime(2016, 11, 4, 12, 34)
+        assert (
+            jinja_filters.merge_date_url(my_date, self.DAY_ARCHIVE_URL)
+            == "posts/2016/11/04/"
+        )
+
+    def test_pelican_strftime(self):
+        my_date = datetime(2021, 7, 7, 0, 0)
+        assert (
+            jinja_filters.merge_date_url(
+                my_date, "posts/{date:%Y}/{date:%-m}/{date:%-d}/"
+            )
+            == "posts/2021/7/7/"
         )
 
 


### PR DESCRIPTION
Building on the groundwork of https://github.com/getpelican/pelican/pull/2902, this aims to support Pelican's custom strftime implementation to allow striping of leading zeros.

Also, it adds better logging for when a filter errors out or pre-commit black does.

Also adds a couple more tests.