### PR TITLE
Add unwrap_links and unwrap_tag filters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,9 @@ At present, the plugin includes the following filters:
 - ``merge_date_url`` |--| given a datetime (on the left) and a supplied URL,
   "apply" the date to it. Envisioned in particular for ``YEAR_ARCHIVE_URL``,
   ``MONTH_ARCHIVE_URL``, and ``DAY_ARCHIVE_URL``.
+- ``unwrap_links`` |--| given a piece of HTML code, it removes the links, keeping the existing text in place.
+- ``unwrap_tag`` |--| given a piece of HTML code, it can remove elements like the ``<b></b>`` bold tags, keeping the existing text in place.
+
 
 For example, within your theme templates, you might have code like:
 

--- a/pelican/plugins/jinja_filters/__init__.py
+++ b/pelican/plugins/jinja_filters/__init__.py
@@ -53,6 +53,8 @@ def add_all_filters(pelican):
         {"datetime_from_period": jinja_filters.datetime_from_period}
     )
     pelican.env.filters.update({"merge_date_url": jinja_filters.merge_date_url})
+    pelican.env.filters.update({"unwrap_tag": jinja_filters.unwrap_tag})
+    pelican.env.filters.update({"unwrap_links": jinja_filters.unwrap_links})
 
 
 def register():

--- a/pelican/plugins/jinja_filters/jinja_filters.py
+++ b/pelican/plugins/jinja_filters/jinja_filters.py
@@ -5,12 +5,15 @@ import logging
 from titlecase import titlecase as _titlecase
 
 from pelican.utils import SafeDatetime
+from bs4 import BeautifulSoup
 
 __all__ = [
     "article_date",
     "breaking_spaces",
     "datetime",
     "titlecase",
+    "unwrap_links",
+    "unwrap_tag",
 ]
 
 
@@ -177,3 +180,44 @@ def titlecase(value):
 
     """
     return _titlecase(value)
+
+
+def unwrap_tag(html, tag_name):
+
+    """Unwrap all tags from the supplied html while keeping the child content.
+
+    ----
+        html (string containing HTML): source
+        tag_name (string): tag name to remove
+
+    Returns:
+    -------
+        str: html, with all matching tags unwrapped.
+
+    """
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+        for a in soup.find_all(tag_name):
+            a.unwrap()
+        return str(soup)
+    except ValueError as e:
+        logger.error(
+            "%s ValueError. value: %s, type(value): %s", LOG_PREFIX, value, type(value)
+        )
+        raise e
+
+
+
+def unwrap_links(html):
+
+    """Remove all hyperlink tags (anchors) from the supplied html while keeping the link content.
+
+    ----
+        html (string containing HTML): source
+
+    Returns:
+    -------
+        str: html, with all anchor tags unwrapped.
+
+    """
+    return unwrap_tag(html, "a")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ requires-python = "~=3.9"
 dependencies = [
     "pelican>=4.5",
     "titlecase>=1.1.1",
+    "beautifulsoup4>=4.0.0",
 ]
 
 [project.urls]

--- a/test/test_unwrap_links.py
+++ b/test/test_unwrap_links.py
@@ -1,0 +1,18 @@
+import unittest
+
+from pelican.plugins.jinja_filters import jinja_filters
+
+
+class Test_Unwrap_Links(unittest.TestCase):
+    def test_basic(self):
+        in_text = "hello,<a href=\"about:blank\">there,<b>visitor</b></a>"
+        out_text = "hello,there,<b>visitor</b></a>"
+        assert jinja_filters.unwrap_links(in_text) == out_text
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_unwrap_tag.py
+++ b/test/test_unwrap_tag.py
@@ -1,0 +1,19 @@
+import unittest
+
+from pelican.plugins.jinja_filters import jinja_filters
+
+
+class Test_Unwrap_Tag(unittest.TestCase):
+    def test_basic(self):
+        in_text = "hello,<a href=\"about:blank\">there,<b>visitor</b></a>"
+        in_text = "hello,<a href=\"about:blank\">there,visitor</a>"
+        tag_name = "b"
+        assert jinja_filters.unwrap_tag(in_text,tag_name) == out_text
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit adds a dependency on beautifulsoup4, it adds two filters, one to remove link HTML tags (unwrap_links), and one that can be used to remove any tag given its name (unwrap_tag). Only the html tags are removed, the child content is preserved.